### PR TITLE
feat($put-request): add logic to handle put request

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-mock",
-  "version": "0.0.0-development",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -7449,7 +7449,7 @@
       "dev": true
     },
     "pretender": {
-      "version": "git+https://github.com/fuse-mars/pretender.git#990da8e05b213e016b578f927f2655cd0b6f6b19",
+      "version": "git+https://github.com/fuse-mars/pretender.git#6e967335a794f88b80af41b8be3457349c45a356",
       "requires": {
         "fake-xml-http-request": "1.6.0",
         "route-recognizer": "0.3.3"
@@ -8277,55 +8277,6 @@
       "requires": {
         "rollup-pluginutils": "2.0.1",
         "source-map-resolve": "0.5.0"
-      }
-    },
-    "rollup-plugin-typescript2": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.10.0.tgz",
-      "integrity": "sha512-Sa2/lFV6VvaMmydyt5lL9L6lk78v2X3x1YpATl2hZIyI/HuiRpP0ls5T3Tmfk3Mniuxx33HXUfmcseIvevqI8Q==",
-      "dev": true,
-      "requires": {
-        "fs-extra": "4.0.3",
-        "resolve": "1.5.0",
-        "rollup-pluginutils": "2.0.1",
-        "tslib": "1.9.0"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
-          "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "4.0.0",
-            "universalify": "0.1.1"
-          }
-        },
-        "jsonfile": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11"
-          }
-        },
-        "resolve": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-          "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
-          "dev": true,
-          "requires": {
-            "path-parse": "1.0.5"
-          }
-        },
-        "tslib": {
-          "version": "1.9.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-          "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
-          "dev": true
-        }
       }
     },
     "rollup-pluginutils": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,10 @@
       "tsx",
       "js"
     ],
+    "testEnvironmentOptions": {
+      "url": "http://localhost:3000/",
+      "referrer": "http://localhost:3000/"
+    },
     "coveragePathIgnorePatterns": [
       "/node_modules/",
       "/test/"

--- a/src/react-mock/index.ts
+++ b/src/react-mock/index.ts
@@ -6,6 +6,8 @@ import Pretender, { ResponseData } from 'pretender'
 
 import DataGeneratorClass, { IDataGenerator } from './data-generator'
 
+import { createPutRoute } from './methods/put'
+
 /**
  * type guard
  * check to see if passed in object implements IDataGenerator
@@ -82,6 +84,19 @@ export default class ServerClass {
         ...others
       )
     })
+  }
+
+  mockPut(
+    endPoint: string,
+    handler: (
+      req: Object,
+      generator: IDataGenerator
+    ) => ResponseData | Promise<ResponseData>,
+    ...others: Array<any>
+  ): void {
+    this.routeMapList.push(
+      createPutRoute(this.dataGenerator, endPoint, handler, ...others)
+    )
   }
 }
 

--- a/src/react-mock/methods/put.ts
+++ b/src/react-mock/methods/put.ts
@@ -1,0 +1,33 @@
+import Pretender, { ResponseData } from 'pretender'
+import { IDataGenerator } from '../data-generator'
+
+/**
+ * @param dg 
+ * @param endPoint 
+ * @param handler 
+ * @param others 
+ */
+export function createPutRoute(
+  dg: IDataGenerator,
+  endPoint: string,
+  handler: (
+    req: Object,
+    generator: IDataGenerator
+  ) => ResponseData | Promise<ResponseData>,
+  ...others: Array<any>
+) {
+  /**
+   * routeMap refers to "pretenderjs" based map of routes that can be passed to an instance of pretenderjs
+   */
+  return function putRouteMap(this: Pretender) {
+    this.put(
+      endPoint,
+      (req: Object) => {
+        return handler(req, dg)
+      },
+      ...others
+    )
+  }
+}
+
+export default createPutRoute


### PR DESCRIPTION
note about using pretenderjs with jsDom is that you will need to add a url to jsdom config so that
you overide the default "about:blank". leaving the default value cause unknown behaviors to
pretender, example of issue that i ran into is "request.params being empty even though the mocked
API specifies the dynamic params"

BREAKING CHANGE: put